### PR TITLE
Add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,20 @@
+# Ignore node_modules directory
+node_modules/
+
+# Ignore public directory
+public/
+
+# Ignore .cache directory
+.cache/
+
+# Ignore .env file
+.env
+
+# Ignore dist directory
+dist/
+
+# Ignore log files
+*.log
+
+# Ignore macOS-specific files
+.DS_Store

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,6 @@
+# Ignore node_modules directory
+node_modules/
+
+# Ignore public directory
+public/
+

--- a/public
+++ b/public
@@ -1,0 +1,6 @@
+# Ignore node_modules directory
+node_modules/
+
+# Ignore public directory
+public/
+


### PR DESCRIPTION
Fixes #5

Add a `.gitignore` file to the repository.

* Add `.gitignore` file to ignore unnecessary files and directories:
  - `node_modules/`
  - `public/`
  - `.cache/`
  - `.env`
  - `dist/`
  - `*.log`
  - `.DS_Store`

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcleigh/jcleigh.github.io/pull/6?shareId=1e303273-633f-4cfe-9e94-4f8c15d33f9e).