### PR TITLE
Fix ENOTDIR error

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,6 @@
 # Ignore node_modules directory
 node_modules/
 
-# Ignore public directory
-public/
-
 # Ignore .cache directory
 .cache/
 

--- a/public
+++ b/public
@@ -1,6 +1,0 @@
-# Ignore node_modules directory
-node_modules/
-
-# Ignore public directory
-public/
-


### PR DESCRIPTION
Fixes #9

Remove the `public` directory from the `.gitignore` file.

* Delete the `public` file.
* Remove the line that ignores the `public` directory in the `.gitignore` file.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcleigh/jcleigh.github.io/pull/10?shareId=c1f96a5a-e392-444d-87b3-e55b69c910db).