### PR TITLE
Add styling to static HTML site

### DIFF
--- a/build.js
+++ b/build.js
@@ -33,11 +33,18 @@ fs.readdir(postsDir, (err, files) => {
         <meta charset="UTF-8">
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>${data.title}</title>
+        <link rel="stylesheet" href="https://unpkg.com/98.css@0.1.0/dist/98.css">
       </head>
       <body>
-        <h1>${data.title}</h1>
-        <p><em>By ${data.author} on ${data.date}</em></p>
-        ${htmlContent}
+        <div class="window">
+          <div class="title-bar">
+            <div class="title-bar-text">${data.title}</div>
+          </div>
+          <div class="window-body">
+            <p><em>By ${data.author} on ${data.date}</em></p>
+            ${htmlContent}
+          </div>
+        </div>
       </body>
       </html>
     `;
@@ -56,13 +63,20 @@ fs.readdir(postsDir, (err, files) => {
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Home</title>
+      <link rel="stylesheet" href="https://unpkg.com/98.css@0.1.0/dist/98.css">
     </head>
     <body>
-      <h1>Home</h1>
-      <ul>
-        ${posts.map(post => `<li><a href="${post.file}">${post.title}</a> - ${post.date}</li>`).join('')}
-      </ul>
-      <a href="about.html">About</a>
+      <div class="window">
+        <div class="title-bar">
+          <div class="title-bar-text">Home</div>
+        </div>
+        <div class="window-body">
+          <ul>
+            ${posts.map(post => `<li><a href="${post.file}">${post.title}</a> - ${post.date}</li>`).join('')}
+          </ul>
+          <a href="about.html">About</a>
+        </div>
+      </div>
     </body>
     </html>
   `;
@@ -76,11 +90,18 @@ fs.readdir(postsDir, (err, files) => {
       <meta charset="UTF-8">
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>About</title>
+      <link rel="stylesheet" href="https://unpkg.com/98.css@0.1.0/dist/98.css">
     </head>
     <body>
-      <h1>About</h1>
-      <p>This is the About page of the blog.</p>
-      <a href="index.html">Home</a>
+      <div class="window">
+        <div class="title-bar">
+          <div class="title-bar-text">About</div>
+        </div>
+        <div class="window-body">
+          <p>This is the About page of the blog.</p>
+          <a href="index.html">Home</a>
+        </div>
+      </div>
     </body>
     </html>
   `;

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "express": "^4.17.1",
     "gray-matter": "^4.0.3",
-    "marked": "^2.0.0"
+    "marked": "^2.0.0",
+    "98.css": "^0.1.0"
   }
 }


### PR DESCRIPTION
Fixes #11

Add styling to the static HTML site using the 98.css library and implement a Windows 98 themed menu UI.

* **package.json**
  - Add `98.css` library to `dependencies` section.

* **build.js**
  - Add link to `98.css` in the `<head>` section of generated HTML files.
  - Add Windows 98 themed menu UI in the `<body>` section of generated HTML files.
  - Wrap content in a `div` with class `window` and add `title-bar` and `window-body` elements for the menu UI.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcleigh/jcleigh.github.io/pull/12?shareId=317e3a32-d56a-468e-9548-0d2bebcb73f4).