### PR TITLE
Add CSS to the static site

### DIFF
--- a/build.js
+++ b/build.js
@@ -11,6 +11,11 @@ if (!fs.existsSync(publicDir)) {
   fs.mkdirSync(publicDir);
 }
 
+// Ensure styles.css is copied to public directory
+const stylesSrc = path.join(__dirname, 'styles.css');
+const stylesDest = path.join(publicDir, 'styles.css');
+fs.copyFileSync(stylesSrc, stylesDest);
+
 // Function to generate top menu bar
 function generateTopMenuBar() {
   return `
@@ -47,6 +52,7 @@ fs.readdir(postsDir, (err, files) => {
         <meta name="viewport" content="width=device-width, initial-scale=1.0">
         <title>${data.title}</title>
         <link rel="stylesheet" href="https://unpkg.com/98.css@0.1.0/dist/98.css">
+        <link rel="stylesheet" href="styles.css">
       </head>
       <body>
         ${generateTopMenuBar()}
@@ -78,6 +84,7 @@ fs.readdir(postsDir, (err, files) => {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>Home</title>
       <link rel="stylesheet" href="https://unpkg.com/98.css@0.1.0/dist/98.css">
+      <link rel="stylesheet" href="styles.css">
     </head>
     <body>
       ${generateTopMenuBar()}
@@ -106,6 +113,7 @@ fs.readdir(postsDir, (err, files) => {
       <meta name="viewport" content="width=device-width, initial-scale=1.0">
       <title>About</title>
       <link rel="stylesheet" href="https://unpkg.com/98.css@0.1.0/dist/98.css">
+      <link rel="stylesheet" href="styles.css">
     </head>
     <body>
       ${generateTopMenuBar()}

--- a/public/styles.css
+++ b/public/styles.css
@@ -1,0 +1,48 @@
+body {
+  font-family: Arial, sans-serif;
+  background-color: #f0f0f0;
+  margin: 0;
+  padding: 0;
+}
+
+.title-bar {
+  background-color: #0078d7;
+  color: white;
+  padding: 10px;
+  text-align: center;
+}
+
+.title-bar-text {
+  font-weight: bold;
+}
+
+.title-bar-controls a {
+  color: white;
+  text-decoration: none;
+  margin: 0 10px;
+}
+
+.window {
+  background-color: white;
+  border: 1px solid #ccc;
+  margin: 20px;
+  padding: 20px;
+  box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+}
+
+.window-body {
+  padding: 10px;
+}
+
+.window-body p {
+  margin: 0 0 10px;
+}
+
+.window-body a {
+  color: #0078d7;
+  text-decoration: none;
+}
+
+.window-body a:hover {
+  text-decoration: underline;
+}


### PR DESCRIPTION
Fixes #15

Add CSS styling to the static site.

* **build.js**
  - Add a link to the local CSS file `styles.css` in the `<head>` section of the generated HTML files.
  - Ensure the `styles.css` file is copied to the `public` directory.

* **public/styles.css**
  - Create a new CSS file `styles.css` in the `public` directory.
  - Add custom styles to the `styles.css` file to style the static site.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/jcleigh/jcleigh.github.io/pull/16?shareId=c09405cf-ed82-46a8-907b-d2cee4a0284e).